### PR TITLE
DM-4813: Skip obs_cfht butler mapper test if datadir isn't found.

### DIFF
--- a/tests/testButler.py
+++ b/tests/testButler.py
@@ -43,6 +43,7 @@ except NameError:
 
 frame = 0
 
+
 class GetRawTestCase(unittest.TestCase):
     """Testing butler raw image retrieval"""
 
@@ -77,7 +78,7 @@ class GetRawTestCase(unittest.TestCase):
             ccd = cameraGeom.cast_Ccd(exp.getDetector())
             for amp in ccd:
                 amp = cameraGeom.cast_Amp(amp)
-                print(ccd.getId(), amp.getId(), amp.getDataSec().toString(), \
+                print(ccd.getId(), amp.getId(), amp.getDataSec().toString(),
                       amp.getBiasSec().toString(), amp.getElectronicParams().getGain())
             cameraGeomUtils.showCcd(ccd, ccdImage=exp, frame=frame)
 
@@ -122,6 +123,7 @@ class GetRawTestCase(unittest.TestCase):
 
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
+
 def suite():
     """Returns a suite containing all the test cases in this module."""
 
@@ -132,7 +134,8 @@ def suite():
     suites += unittest.makeSuite(utilsTests.MemoryTestCase)
     return unittest.TestSuite(suites)
 
-def run(shouldExit = False):
+
+def run(shouldExit=False):
     """Run the tests"""
     utilsTests.run(suite(), shouldExit)
 

--- a/tests/testButler.py
+++ b/tests/testButler.py
@@ -22,6 +22,8 @@
 # see <http://www.lsstcorp.org/LegalNotices/>.
 #
 
+from __future__ import print_function
+
 import os
 import sys
 
@@ -58,12 +60,12 @@ class GetRawTestCase(unittest.TestCase):
             del self.butler
 
     def assertExposure(self, exp, ccd, checkFilter=True):
-        print "dataId: ", self.dataId
-        print "ccd: ", ccd
-        print "width: ", exp.getWidth()
-        print "height: ", exp.getHeight()
-        print "detector name: ", exp.getDetector().getName()
-        print "filter name: ", exp.getFilter().getFilterProperty().getName()
+        print("dataId: ", self.dataId)
+        print("ccd: ", ccd)
+        print("width: ", exp.getWidth())
+        print("height: ", exp.getHeight())
+        print("detector name: ", exp.getDetector().getName())
+        print("filter name: ", exp.getFilter().getFilterProperty().getName())
 
         self.assertEqual(exp.getWidth(), self.size[0])
         self.assertEqual(exp.getHeight(), self.size[1])
@@ -77,8 +79,8 @@ class GetRawTestCase(unittest.TestCase):
             ccd = cameraGeom.cast_Ccd(exp.getDetector())
             for amp in ccd:
                 amp = cameraGeom.cast_Amp(amp)
-                print ccd.getId(), amp.getId(), amp.getDataSec().toString(), \
-                      amp.getBiasSec().toString(), amp.getElectronicParams().getGain()
+                print(ccd.getId(), amp.getId(), amp.getDataSec().toString(), \
+                      amp.getBiasSec().toString(), amp.getElectronicParams().getGain())
             cameraGeomUtils.showCcd(ccd, ccdImage=exp, frame=frame)
 
     def getTestDataDir(self):
@@ -86,7 +88,8 @@ class GetRawTestCase(unittest.TestCase):
         if datadir:
             return datadir
         else:
-            print >> sys.stderr, "Skipping test as testdata_cfht is not setup"
+            print("Skipping test as testdata_cfht is not setup", 
+                  file=sys.stderr) 
 
     def testRaw(self):
         """Test retrieval of raw image"""
@@ -107,7 +110,7 @@ class GetRawTestCase(unittest.TestCase):
         if not self.runTests:
             return
         for ccd in range(36):
-            flat = self.butler.get(detrend, self.dataId, ccd=ccd)
+            flat = self.butler.get(detrend, self.dataId, ccd=ccd, immediate=True)
 
             self.assertExposure(flat, ccd, checkFilter=False)
 

--- a/tests/testButler.py
+++ b/tests/testButler.py
@@ -130,6 +130,8 @@ class GetRawTestCase(unittest.TestCase):
         self.getDetrend("fringe")
 
     def testPackageName(self):
+        if not self.runTests:
+            return
         self.assertEqual(self.butler.mapper.packageName, "obs_cfht")
 
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-

--- a/tests/testButler.py
+++ b/tests/testButler.py
@@ -2,7 +2,7 @@
 
 #
 # LSST Data Management System
-# Copyright 2012 LSST Corporation.
+# Copyright 2012-2016 LSST Corporation.
 #
 # This product includes software developed by the
 # LSST Project (http://www.lsst.org/).
@@ -28,10 +28,13 @@ import os
 import sys
 
 import unittest
+import warnings
+from lsst.utils import getPackageDir
 import lsst.utils.tests as utilsTests
 import lsst.daf.persistence as dafPersist
 import lsst.afw.cameraGeom as cameraGeom
 import lsst.afw.cameraGeom.utils as cameraGeomUtils
+import lsst.pex.exceptions as pexExcept
 
 try:
     type(display)
@@ -45,19 +48,14 @@ class GetRawTestCase(unittest.TestCase):
 
     def setUp(self):
         datadir = self.getTestDataDir()
-        if datadir:
-            self.butler = dafPersist.Butler(root=os.path.join(datadir, "DATA"),
-                                            calibRoot=os.path.join(datadir, "CALIB"))
-            self.size = (2112, 4644)
-            self.dataId = {'visit': 1038843}
-            self.filter = "i2"
-            self.runTests = True
-        else:
-            self.runTests = False
+        self.butler = dafPersist.Butler(root=os.path.join(datadir, "DATA"),
+                                        calibRoot=os.path.join(datadir, "CALIB"))
+        self.size = (2112, 4644)
+        self.dataId = {'visit': 1038843}
+        self.filter = "i2"
 
     def tearDown(self):
-        if self.runTests:
-            del self.butler
+        del self.butler
 
     def assertExposure(self, exp, ccd, checkFilter=True):
         print("dataId: ", self.dataId)
@@ -84,17 +82,15 @@ class GetRawTestCase(unittest.TestCase):
             cameraGeomUtils.showCcd(ccd, ccdImage=exp, frame=frame)
 
     def getTestDataDir(self):
-        datadir = os.getenv("TESTDATA_CFHT_DIR")
-        if datadir:
-            return datadir
-        else:
-            print("Skipping test as testdata_cfht is not setup", 
-                  file=sys.stderr) 
+        try:
+            datadir = getPackageDir("testdata_cfht")
+        except pexExcept.NotFoundError as e:
+            warnings.warn(e.message)
+            raise unittest.SkipTest("Skipping test as testdata_cfht is not setup")
+        return datadir
 
     def testRaw(self):
         """Test retrieval of raw image"""
-        if not self.runTests:
-            return
         if display:
             global frame
             frame += 1
@@ -107,31 +103,21 @@ class GetRawTestCase(unittest.TestCase):
 
     def getDetrend(self, detrend):
         """Test retrieval of detrend image"""
-        if not self.runTests:
-            return
         for ccd in range(36):
             flat = self.butler.get(detrend, self.dataId, ccd=ccd, immediate=True)
 
             self.assertExposure(flat, ccd, checkFilter=False)
 
     def testFlat(self):
-        if not self.runTests:
-            return
         self.getDetrend("flat")
 
     def testBias(self):
-        if not self.runTests:
-            return
         self.getDetrend("bias")
 
     def testFringe(self):
-        if not self.runTests:
-            return
         self.getDetrend("fringe")
 
     def testPackageName(self):
-        if not self.runTests:
-            return
         self.assertEqual(self.butler.mapper.packageName, "obs_cfht")
 
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-


### PR DESCRIPTION
Skip tests in Butler mapper test suite by raising unittest.SkipTest if `testdata_cfht` isn't set up.

This then skips the full set of butler+mapping tests in that testing suite.

The availability of `testdata_cfht` is tested with `utils.getPackageDir`.