### PR TITLE
Review for DM-9431: Please do not use Exception.message

### DIFF
--- a/tests/testButler.py
+++ b/tests/testButler.py
@@ -111,7 +111,7 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
         try:
             datadir = getPackageDir("testdata_cfht")
         except pexExcept.NotFoundError as e:
-            warnings.warn(e.message)
+            warnings.warn(e.args[0])
             raise unittest.SkipTest("Skipping test as testdata_cfht is not setup")
         return datadir
 


### PR DESCRIPTION
This attribute does not exist in Python 3. We use ``e.args[0]`` (rather than
``str(e))``) because it results in more readable output.