### PR TITLE
Reset filters before defining them

### DIFF
--- a/python/lsst/obs/cfht/megacamMapper.py
+++ b/python/lsst/obs/cfht/megacamMapper.py
@@ -54,6 +54,7 @@ class MegacamMapper(CameraMapper):
 
         self.exposures['raw'].keyDict['ccd'] = int
 
+        afwImageUtils.resetFilters()
         afwImageUtils.defineFilter('u', lambdaEff=374, alias="u.MP9301")
         afwImageUtils.defineFilter('u2', lambdaEff=354, alias="u.MP9302")
         afwImageUtils.defineFilter('g', lambdaEff=487, alias="g.MP9401")


### PR DESCRIPTION
Without this, the jointcal tests fail (first attempt was in lsst/jointcal#48).