### PR TITLE
DM-13163: Refactor ap_pipe to use CmdLineTask primitives

### DIFF
--- a/policy/MegacamMapper.yaml
+++ b/policy/MegacamMapper.yaml
@@ -225,6 +225,8 @@ datasets:
     python: lsst.meas.base.forcedPhotCoadd.ForcedPhotCoaddConfig
     storage: ConfigStorage
     template: config/forcedPhotCoadd.py
+  apPipe_metadata:
+    template: metadata/%(runId)s/%(object)s/%(date)s/%(filter)s/MD-apPipe-%(visit)d-%(ccd)02d.boost
 
   # Detections on coadds
 


### PR DESCRIPTION
This PR registers a dataset mapping for metadata persisted by `ApPipeTask`. The config dataset is delegated to `obs_base`.