### PR TITLE
DM-6640: IsrTask is not a valid CmdLineTask

### DIFF
--- a/config/isr.py
+++ b/config/isr.py
@@ -1,0 +1,14 @@
+"""
+CFHT-specific overrides for IsrTask
+"""
+config.doBias = False
+config.doDark = False
+config.doFlat = False
+config.doFringe = False
+config.fringeAfterFlat = False
+config.doWrite = False
+config.fringe.filters = ['i', 'i2', 'z']
+config.fringe.pedestal = True
+config.fringe.small = 1
+config.fringe.large = 50
+config.doAssembleIsrExposures = True

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -1,24 +1,17 @@
+"""
+CFHT-specific overrides for processCcdTask
+"""
 import os.path
 
 from lsst.utils import getPackageDir
-
-cfhtConfigDir = os.path.join(getPackageDir("obs_cfht"), "config")
-config.calibrate.photoCal.colorterms.load(os.path.join(cfhtConfigDir, 'colorterms.py'))
-
 from lsst.obs.cfht.cfhtIsrTask import CfhtIsrTask
-config.isr.retarget(CfhtIsrTask)
 
-config.isr.doBias = False
-config.isr.doDark = False
-config.isr.doFlat = False
-config.isr.doFringe = False
-config.isr.fringeAfterFlat = False
-config.isr.doWrite = False
-config.isr.fringe.filters = ['i', 'i2', 'z']
-config.isr.fringe.pedestal = True
-config.isr.fringe.small = 1
-config.isr.fringe.large = 50
-config.isr.doAssembleIsrExposures = True
+obsConfigDir = os.path.join(getPackageDir("obs_cfht"), "config")
+
+config.isr.retarget(CfhtIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))
+
+config.calibrate.photoCal.colorterms.load(os.path.join(obsConfigDir, 'colorterms.py'))
 
 config.charImage.repair.doCosmicRay = True
 config.charImage.repair.cosmicray.cond3_fac = 2.5

--- a/config/runIsr.py
+++ b/config/runIsr.py
@@ -1,0 +1,12 @@
+"""
+CFHT-specific overrides for RunIsrTask
+"""
+import os.path
+
+from lsst.utils import getPackageDir
+from lsst.obs.cfht.cfhtIsrTask import CfhtIsrTask
+
+obsConfigDir = os.path.join(getPackageDir("obs_cfht"), "config")
+
+config.isr.retarget(CfhtIsrTask)
+config.isr.load(os.path.join(obsConfigDir, "isr.py"))


### PR DESCRIPTION
This ticket adds a stand-alone runIsr.py script, as well as ensuring that runIsr.py and processCcd.py read the same ISR configuration files.
