### PR TITLE
DM-21860: Add Gen3 support to obs_cfht

### DIFF
--- a/bin.src/megacamCalibRegistry.py
+++ b/bin.src/megacamCalibRegistry.py
@@ -63,7 +63,8 @@ filterNames = {0: 'NONE',
 
 
 def fixString(s):
-    """Work around apparent pyfits bug: it's not terminating strings at the NULL"""
+    """Work around apparent pyfits bug: it's not terminating strings at the
+    NULL"""
     c = s.find('\0')
     return s if c == -1 else s[:c]
 
@@ -106,8 +107,8 @@ def parseDetrendDatabase(tableName, create=False):
         imageType = imageTypes[imageType]
         filterName = filterNames[filtNum]
 
-        # Remove multiple versions, since our own software doesn't yet handle selection
-        # among multiple versions
+        # Remove multiple versions, since our own software doesn't yet handle
+        # selection among multiple versions
         cur = conn.cursor()
         cmd = "DELETE FROM " + imageType + \
             " WHERE FILTER = ? AND validStart = ? AND validEnd = ? AND version <= ?"

--- a/bin/genDefects.py
+++ b/bin/genDefects.py
@@ -11,11 +11,13 @@ import numpy as np
 
 def makeBBList(mask, ccd):
 
-    # Create a bounding box corresponding to the useful part of the CCD (exclude overscan regions)
+    # Create a bounding box corresponding to the useful part of the CCD
+    # (exclude overscan regions)
     bb = geom.Box2I(geom.Point2I(32, 0), geom.Point2I(2079, 4611))
     # Read mask file provided by Elixir team
     im = afwImage.ImageF('%s.fits['%mask + str(ccd+1) + ']', bbox=bb, origin=afwImage.ImageOrigin.PARENT)
-    # Pixel values in mask files are 1 for background and 0 for bad pixels - Need to inverse this
+    # Pixel values in mask files are 1 for background and 0 for bad pixels
+    # - Need to inverse this
     im *= -1.
     im += 1.
     im *= 10.

--- a/megacam/camera/camera.py
+++ b/megacam/camera/camera.py
@@ -2230,4 +2230,4 @@ config.detectorList[35].id = 35
 config.radialCoeffs = None
 
 # Name of this camera
-config.name = 'CFHT MegaCam'
+config.name = 'MegaPrime'

--- a/python/lsst/obs/cfht/__init__.py
+++ b/python/lsst/obs/cfht/__init__.py
@@ -21,3 +21,5 @@
 #
 from .version import *
 from .megacamMapper import *
+from ._instrument import MegaPrime
+from .ingest import MegaPrimeRawIngestTask

--- a/python/lsst/obs/cfht/_instrument.py
+++ b/python/lsst/obs/cfht/_instrument.py
@@ -1,0 +1,111 @@
+# This file is part of obs_cfht.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Butler instrument description for the CFHT MegaCam camera.
+"""
+
+__all__ = ("MegaPrime",)
+
+import os
+from functools import lru_cache
+
+from lsst.afw.cameraGeom import makeCameraFromPath, CameraConfig
+from lsst.obs.base import Instrument
+from lsst.obs.base.gen2to3 import TranslatorFactory, AbstractToPhysicalFilterKeyHandler
+from .cfhtFilters import MEGAPRIME_FILTER_DEFINITIONS
+
+from lsst.daf.butler.core.utils import getFullTypeName
+from lsst.utils import getPackageDir
+
+
+class MegaPrime(Instrument):
+    filterDefinitions = MEGAPRIME_FILTER_DEFINITIONS
+    policyName = "megacam"
+    obsDataPackage = None
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        packageDir = getPackageDir("obs_cfht")
+        self.configPaths = [os.path.join(packageDir, "config")]
+
+    @classmethod
+    def getName(cls):
+        return "MegaPrime"
+
+    def getCamera(self):
+        path = os.path.join(getPackageDir("obs_cfht"), self.policyName, "camera")
+        return self._getCameraFromPath(path)
+
+    @staticmethod
+    @lru_cache()
+    def _getCameraFromPath(path):
+        """Return the camera geometry given solely the path to the location
+        of that definition."""
+        config = CameraConfig()
+        config.load(os.path.join(path, "camera.py"))
+        return makeCameraFromPath(
+            cameraConfig=config,
+            ampInfoPath=path,
+            shortNameFunc=lambda name: name.replace(" ", "_"),
+        )
+
+    def register(self, registry):
+        camera = self.getCamera()
+        obsMax = 2**31
+        registry.insertDimensionData(
+            "instrument",
+            {"name": self.getName(), "detector_max": 36, "visit_max": obsMax, "exposure_max": obsMax,
+             "class_name": getFullTypeName(self),
+             }
+        )
+
+        for detector in camera:
+            registry.insertDimensionData(
+                "detector",
+                {
+                    "instrument": self.getName(),
+                    "id": detector.getId(),
+                    "full_name": detector.getName(),
+                    "name_in_raft": detector.getName(),
+                    "raft": None,  # MegaPrime does not have rafts
+                    "purpose": str(detector.getType()).split(".")[-1],
+                }
+            )
+
+        self._registerFilters(registry)
+
+    def getRawFormatter(self, dataId):
+        # local import to prevent circular dependency
+        from .rawFormatter import MegaPrimeRawFormatter
+        return MegaPrimeRawFormatter
+
+    def makeDataIdTranslatorFactory(self) -> TranslatorFactory:
+        # Docstring inherited from lsst.obs.base.Instrument.
+        factory = TranslatorFactory()
+        factory.addGenericInstrumentRules(self.getName(), calibFilterType="abstract_filter")
+
+        # calibRegistry entries are abstract_filters, but we need physical_filter
+        # in the gen3 registry.
+        factory.addRule(AbstractToPhysicalFilterKeyHandler(self.filterDefinitions),
+                        instrument=self.getName(),
+                        gen2keys=("filter",),
+                        consume=("filter",))
+        return factory

--- a/python/lsst/obs/cfht/_instrument.py
+++ b/python/lsst/obs/cfht/_instrument.py
@@ -102,8 +102,8 @@ class MegaPrime(Instrument):
         factory = TranslatorFactory()
         factory.addGenericInstrumentRules(self.getName(), calibFilterType="abstract_filter")
 
-        # calibRegistry entries are abstract_filters, but we need physical_filter
-        # in the gen3 registry.
+        # calibRegistry entries are abstract_filters, but we need
+        # physical_filter in the gen3 registry.
         factory.addRule(AbstractToPhysicalFilterKeyHandler(self.filterDefinitions),
                         instrument=self.getName(),
                         gen2keys=("filter",),

--- a/python/lsst/obs/cfht/cfhtFilters.py
+++ b/python/lsst/obs/cfht/cfhtFilters.py
@@ -1,0 +1,89 @@
+# This file is part of obs_cfht.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__all__ = ("MEGAPRIME_FILTER_DEFINITIONS",)
+
+from lsst.obs.base import FilterDefinition, FilterDefinitionCollection
+
+# Filter specification comes from
+# https://www.cfht.hawaii.edu/Instruments/Filters/megaprimenew.html
+
+# With current afwFilter singleton we can not define abstract filters
+# properly since we are only allowed one u alias.
+MEGAPRIME_FILTER_DEFINITIONS = FilterDefinitionCollection(
+    FilterDefinition(physical_filter="u.MP9301",
+                     abstract_filter="u",
+                     lambdaEff=374, lambdaMin=336, lambdaMax=412),
+    FilterDefinition(physical_filter="u.MP9302",
+                     abstract_filter="u2",
+                     alias={"u2"},
+                     lambdaEff=354, lambdaMin=310, lambdaMax=397),
+    FilterDefinition(physical_filter="u.MP9303",
+                     abstract_filter="u3",
+                     lambdaEff=395, lambdaMin=390, lambdaMax=400),
+    FilterDefinition(physical_filter="g.MP9401",
+                     abstract_filter="g",
+                     lambdaEff=487, lambdaMin=414, lambdaMax=560),
+    FilterDefinition(physical_filter="g.MP9402",
+                     abstract_filter="g2",
+                     alias={"g2"},
+                     lambdaEff=472, lambdaMin=396, lambdaMax=548),
+    FilterDefinition(physical_filter="g.MP9501",
+                     abstract_filter="g3",
+                     lambdaEff=501, lambdaMin=495, lambdaMax=506),
+    FilterDefinition(physical_filter="g.MP9502",
+                     abstract_filter="g4",
+                     lambdaEff=511, lambdaMin=506, lambdaMax=516),
+    FilterDefinition(physical_filter="r.MP9601",
+                     abstract_filter="r",
+                     lambdaEff=628, lambdaMin=567, lambdaMax=689),
+    FilterDefinition(physical_filter="r.MP9602",
+                     abstract_filter="r2",
+                     alias={"r2"},
+                     lambdaEff=640, lambdaMin=566, lambdaMax=714),
+    FilterDefinition(physical_filter="r.MP9603",
+                     abstract_filter="r3",
+                     lambdaEff=659, lambdaMin=654, lambdaMax=664),
+    FilterDefinition(physical_filter="r.MP9604",
+                     abstract_filter="r4",
+                     lambdaEff=672, lambdaMin=666, lambdaMax=677),
+    FilterDefinition(physical_filter="r.MP9605",
+                     abstract_filter="r5",
+                     lambdaEff=611, lambdaMin=400, lambdaMax=821),
+    FilterDefinition(physical_filter="i.MP9701",
+                     abstract_filter="i",
+                     lambdaEff=778, lambdaMin=702, lambdaMax=853,),
+    FilterDefinition(physical_filter="i.MP9702",
+                     abstract_filter="i2",
+                     alias={"i2"},
+                     lambdaEff=764, lambdaMin=684, lambdaMax=845),
+    FilterDefinition(physical_filter="i.MP9703",
+                     abstract_filter="i3",
+                     alias={"i3"},
+                     lambdaEff=776, lambdaMin=696, lambdaMax=857,),
+    FilterDefinition(physical_filter="z.MP9801",
+                     abstract_filter="z",
+                     lambdaEff=1170, lambdaMin=827, lambdaMax=1514),
+    FilterDefinition(physical_filter="z.MP9901",
+                     abstract_filter="z2",
+                     alias={"z2"},
+                     lambdaEff=926, lambdaMin=849, lambdaMax=1002),
+)

--- a/python/lsst/obs/cfht/cfhtIsrTask.py
+++ b/python/lsst/obs/cfht/cfhtIsrTask.py
@@ -46,7 +46,7 @@ class CfhtIsrTask(IsrTask):
             Exposure of flatfield.
         defects : `list`
             list of detects
-        fringes : `lsst.afw.image.exposure` or `list` of `lsst.afw.image.exposure`
+        fringes : `lsst.afw.image.Exposure` or list `lsst.afw.image.Exposure`
             exposure of fringe frame or list of fringe exposure
         bfKernel : None
             kernel used for brighter-fatter correction; currently unsupported

--- a/python/lsst/obs/cfht/megacamMapper.py
+++ b/python/lsst/obs/cfht/megacamMapper.py
@@ -50,8 +50,9 @@ class MegacamMapper(CameraMapper):
         repositoryDir = os.path.dirname(policyFile)
         super(MegacamMapper, self).__init__(policy, repositoryDir, **kwargs)
 
-        # Defect registry and root. Defects are stored with the camera and the registry is loaded from the
-        # camera package, which is on the local filesystem.
+        # Defect registry and root. Defects are stored with the camera and the
+        #  registry is loaded from the camera package, which is on the local
+        # filesystem.
         self.defectRegistry = None
         if 'defects' in policy:
             self.defectPath = os.path.join(repositoryDir, policy['defects'])
@@ -98,16 +99,16 @@ class MegacamMapper(CameraMapper):
             self.mappings[name].keyDict.update(keys)
 
         #
-        # The number of bits allocated for fields in object IDs, appropriate for
-        # the default-configured Rings skymap.
+        # The number of bits allocated for fields in object IDs, appropriate
+        # for the default-configured Rings skymap.
         #
 
         MegacamMapper._nbit_tract = 16
         MegacamMapper._nbit_patch = 5
         MegacamMapper._nbit_filter = 6
 
-        MegacamMapper._nbit_id = 64 - (MegacamMapper._nbit_tract + 2*MegacamMapper._nbit_patch +
-                                       MegacamMapper._nbit_filter)
+        MegacamMapper._nbit_id = 64 - (MegacamMapper._nbit_tract + 2*MegacamMapper._nbit_patch
+                                       + MegacamMapper._nbit_filter)
 
         if len(afwImageUtils.Filter.getNames()) >= 2**MegacamMapper._nbit_filter:
             raise RuntimeError("You have more filters defined than fit into the %d bits allocated" %

--- a/python/lsst/obs/cfht/megacamMapper.py
+++ b/python/lsst/obs/cfht/megacamMapper.py
@@ -34,11 +34,13 @@ import lsst.daf.persistence as dafPersist
 from lsst.daf.persistence import Policy
 from lsst.obs.base import CameraMapper, exposureFromImage
 from .makeMegacamRawVisitInfo import MakeMegacamRawVisitInfo
+from ._instrument import MegaPrime
 
 
 class MegacamMapper(CameraMapper):
     """Camera Mapper for CFHT MegaCam."""
     packageName = "obs_cfht"
+    _gen3instrument = MegaPrime
 
     MakeRawVisitInfoClass = MakeMegacamRawVisitInfo
 

--- a/python/lsst/obs/cfht/rawFormatter.py
+++ b/python/lsst/obs/cfht/rawFormatter.py
@@ -1,0 +1,139 @@
+# This file is part of obs_cfht.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import lsst.afw.image
+import lsst.afw.fits
+from lsst.obs.base import FitsRawFormatterBase
+from astro_metadata_translator import MegaPrimeTranslator, fix_header
+import logging
+
+from .cfhtFilters import MEGAPRIME_FILTER_DEFINITIONS
+from ._instrument import MegaPrime
+
+__all__ = ("MegaPrimeRawFormatter",)
+
+log = logging.getLogger(__name__)
+
+
+class MegaPrimeRawFormatter(FitsRawFormatterBase):
+    """Gen3 Butler formatter for MegaPrime raw data.
+
+    MegaPrime uses multi-extension FITS files.
+    """
+
+    translatorClass = MegaPrimeTranslator
+    filterDefinitions = MEGAPRIME_FILTER_DEFINITIONS
+
+    def getDetector(self, id):
+        return MegaPrime().getCamera()[id]
+
+    def _toExtName(self, detectorId):
+        """Return the extension name associated with the given detector.
+
+        Parameters
+        ----------
+        detectorId : `int`
+            The detector ID to search for.
+
+        Returns
+        -------
+        name : `str`
+            The name of the extension associated with this detector.
+        """
+        return f"ccd{detectorId:02d}"
+
+    def _scanHdus(self, filename, detectorId):
+        """Scan through a file for the HDU containing data from one detector.
+
+        Parameters
+        ----------
+        filename : `str`
+            The file to search through.
+        detectorId : `int`
+            The detector id to search for.
+
+        Returns
+        -------
+        index : `int`
+            The index of the HDU with the requested data.
+        metadata: `lsst.daf.base.PropertyList`
+            The metadata read from the header for that detector id.
+
+        Raises
+        ------
+        ValueError
+            Raised if detectorId is not found in any of the file HDUs
+        """
+        fitsData = lsst.afw.fits.Fits(filename, 'r')
+        # NOTE: The primary header (HDU=0) does not contain detector data.
+        extname = self._toExtName(detectorId)
+        for i in range(1, fitsData.countHdus()):
+            fitsData.setHdu(i)
+            metadata = fitsData.readMetadata()
+            if metadata.get("EXTNAME") == extname:
+                log.debug("Found detector %s in extension %s", detectorId, i)
+                return i, metadata
+        else:
+            raise ValueError(f"Did not find detectorId={detectorId} in any HDU of {filename}.")
+
+    def _determineHDU(self, detectorId):
+        """Determine the correct HDU number for a given detector id.
+
+        Parameters
+        ----------
+        detectorId : `int`
+            The detector id to search for.
+
+        Returns
+        -------
+        index : `int`
+            The index of the HDU with the requested data.
+        metadata : `lsst.daf.base.PropertyList`
+            The metadata read from the header for that detector id.
+
+        Raises
+        ------
+        ValueError
+            Raised if detectorId is not found in any of the file HDUs
+        """
+        filename = self.fileDescriptor.location.path
+        # We start by assuming that ccdN is HDU N+1
+        index = detectorId + 1
+        metadata = lsst.afw.fits.readMetadata(filename, index)
+
+        # There may be two EXTNAME headers but the second one is the one
+        # we want (the first indicates compression).
+        if metadata.get("EXTNAME") == self._toExtName(detectorId):
+            return index, metadata
+
+        log.info("Did not find detector=%s at expected HDU=%s in %s: scanning through all HDUs.",
+                 detectorId, index, filename)
+        return self._scanHdus(filename, detectorId)
+
+    def readMetadata(self):
+        # Headers are duplicated so no need to merge with primary
+        index, metadata = self._determineHDU(self.dataId["detector"])
+        fix_header(metadata)
+        return metadata
+
+    def readImage(self):
+        index, metadata = self._determineHDU(self.dataId["detector"])
+        return lsst.afw.image.ImageI(self.fileDescriptor.location.path, index)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [flake8]
 max-line-length = 110
-ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W504
+max-doc-length = 79
+ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503
 exclude =
     __init__.py,
     config/*
@@ -9,4 +10,4 @@ exclude =
 
 [tool:pytest]
 addopts = --flake8
-flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W504
+flake8-ignore = E133 E226 E228 N802 N803 N806 N812 N815 N816 W503

--- a/tests/SConscript
+++ b/tests/SConscript
@@ -1,3 +1,7 @@
 # -*- python -*-
-from lsst.sconsUtils import scripts
+import os
+from lsst.sconsUtils import env, scripts
 scripts.BasicSConscript.tests(pyList=[])
+
+if "DAF_BUTLER_PLUGINS" in os.environ:
+    env["ENV"]["DAF_BUTLER_PLUGINS"] = os.environ["DAF_BUTLER_PLUGINS"]

--- a/tests/test_butler.py
+++ b/tests/test_butler.py
@@ -69,7 +69,8 @@ class GetRawTestCase(lsst.utils.tests.TestCase):
         self.weath_airTemperature = 0.90
         self.weath_airPressure = 617.65*100  # 100 Pascal/millibar
         self.weath_humidity = 39.77
-        # NOTE: if we deal with DM-8053 and get UT1 implemented, ERA will change slightly.
+        # NOTE: if we deal with DM-8053 and get UT1 implemented,
+        # ERA will change slightly.
         self.era = 4.55388*radians
 
     def tearDown(self):

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,85 @@
+# This file is part of obs_cfht.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Unit tests for Gen3 CFHT raw data ingest.
+"""
+
+import unittest
+import os
+import lsst.utils.tests
+
+from lsst.daf.butler import Butler, DataCoordinate
+from lsst.obs.base.ingest_tests import IngestTestBase
+
+testDataPackage = "testdata_cfht"
+try:
+    testDataDirectory = lsst.utils.getPackageDir(testDataPackage)
+except LookupError:
+    testDataDirectory = None
+
+
+@unittest.skipIf(testDataDirectory is None, f"{testDataPackage} must be set up")
+class MegaPrimeIngestTestCase(IngestTestBase, lsst.utils.tests.TestCase):
+
+    curatedCalibrationDatasetTypes = ()
+    ingestDir = os.path.dirname(__file__)
+    instrumentClassName = "lsst.obs.cfht.MegaPrime"
+    rawIngestTask = "lsst.obs.cfht.MegaPrimeRawIngestTask"
+
+    @property
+    def file(self):
+        return os.path.join(testDataDirectory, "DATA/raw/08BL05/w2.+2+2/2008-11-01/i2/1038843o.fits.fz")
+
+    dataIds = [dict(instrument="MegaPrime", exposure=1038843, detector=i) for i in range(36)]
+
+    @property
+    def visits(self):
+        butler = Butler(self.root, collections=[self.outputRun])
+        return {
+            DataCoordinate.standardize(
+                instrument="MegaPrime",
+                visit=1038843,
+                universe=butler.registry.dimensions
+            ): [
+                DataCoordinate.standardize(
+                    instrument="MegaPrime",
+                    exposure=1038843,
+                    universe=butler.registry.dimensions
+                )
+            ]
+        }
+
+    def checkRepo(self, files=None):
+        # We ignore `files` because there's only one raw file in
+        # testdata_subaru, and we know it's a science frame.
+        # If we ever add more, this test will need to change.
+        butler = Butler(self.root, collections=[self.outputRun])
+        expanded = butler.registry.expandDataId(self.dataIds[0])
+        self.assertEqual(expanded.records["exposure"].observation_type, "science")
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_instrument.py
+++ b/tests/test_instrument.py
@@ -1,0 +1,71 @@
+# This file is part of daf_butler.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (http://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests of the HyperSuprimeCam instrument class.
+"""
+
+import unittest
+
+import lsst.utils.tests
+import lsst.obs.cfht
+from lsst.obs.base.instrument_tests import InstrumentTests, InstrumentTestData
+
+
+class TestMegaCam(InstrumentTests, lsst.utils.tests.TestCase):
+    def setUp(self):
+        physical_filters = {
+            "u.MP9301",
+            "u.MP9302",
+            "u.MP9303",
+            "g.MP9401",
+            "g.MP9402",
+            "g.MP9501",
+            "g.MP9502",
+            "r.MP9601",
+            "r.MP9602",
+            "r.MP9603",
+            "r.MP9604",
+            "r.MP9605",
+            "i.MP9701",
+            "i.MP9702",
+            "i.MP9703",
+            "z.MP9801",
+            "z.MP9901",
+        }
+        self.data = InstrumentTestData(name="MegaPrime",
+                                       nDetectors=36,
+                                       firstDetectorName="ccd00",
+                                       physical_filters=physical_filters)
+
+        self.instrument = lsst.obs.cfht.MegaPrime()
+
+
+class MemoryTester(lsst.utils.tests.MemoryTestCase):
+    pass
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == '__main__':
+    lsst.utils.tests.init()
+    unittest.main()


### PR DESCRIPTION
This currently creates an `MegaPrime` instrument and a very simple raw formatter. I can `butler ingest-raws` successfully and I have checked that the gen2 WCS and gen3 WCS from raws agree (although gen2 `raw_wcs` seems to be broken and inconsistent -- works fine if I get the `raw` and then get the `wcs`).