### PR TITLE
DM-25807: Suppress known deprecated Filter calls

### DIFF
--- a/python/lsst/obs/cfht/megacamMapper.py
+++ b/python/lsst/obs/cfht/megacamMapper.py
@@ -23,6 +23,7 @@
 __all__ = ["MegacamMapper"]
 
 import os
+import warnings
 
 from astropy.io import fits
 
@@ -67,17 +68,21 @@ class MegacamMapper(CameraMapper):
 
         self.exposures['raw'].keyDict['ccd'] = int
 
-        afwImageUtils.defineFilter('u', lambdaEff=374, alias="u.MP9301")
-        afwImageUtils.defineFilter('u2', lambdaEff=354, alias="u.MP9302")
-        afwImageUtils.defineFilter('g', lambdaEff=487, alias="g.MP9401")
-        afwImageUtils.defineFilter('g2', lambdaEff=472, alias="g.MP9402")
-        afwImageUtils.defineFilter('r', lambdaEff=628, alias="r.MP9601")
-        afwImageUtils.defineFilter('r2', lambdaEff=640, alias="r.MP9602")
-        afwImageUtils.defineFilter('i', lambdaEff=778, alias="i.MP9701")
-        afwImageUtils.defineFilter('i2', lambdaEff=764, alias="i.MP9702")
-        afwImageUtils.defineFilter('i3', lambdaEff=776, alias="i.MP9703")
-        afwImageUtils.defineFilter('z', lambdaEff=1170, alias="z.MP9801")
-        afwImageUtils.defineFilter('z2', lambdaEff=926, alias="z.MP9901")
+        with warnings.catch_warnings():
+            # surpress Filter warnings; we already know this is deprecated
+            warnings.simplefilter('ignore', category=FutureWarning)
+
+            afwImageUtils.defineFilter('u', lambdaEff=374, alias="u.MP9301")
+            afwImageUtils.defineFilter('u2', lambdaEff=354, alias="u.MP9302")
+            afwImageUtils.defineFilter('g', lambdaEff=487, alias="g.MP9401")
+            afwImageUtils.defineFilter('g2', lambdaEff=472, alias="g.MP9402")
+            afwImageUtils.defineFilter('r', lambdaEff=628, alias="r.MP9601")
+            afwImageUtils.defineFilter('r2', lambdaEff=640, alias="r.MP9602")
+            afwImageUtils.defineFilter('i', lambdaEff=778, alias="i.MP9701")
+            afwImageUtils.defineFilter('i2', lambdaEff=764, alias="i.MP9702")
+            afwImageUtils.defineFilter('i3', lambdaEff=776, alias="i.MP9703")
+            afwImageUtils.defineFilter('z', lambdaEff=1170, alias="z.MP9801")
+            afwImageUtils.defineFilter('z2', lambdaEff=926, alias="z.MP9901")
 
         # define filters?
         self.filterIdMap = dict(u=0, g=1, r=2, i=3, z=4, i2=5, u2=6, g2=7, r2=8, i3=9, z2=10)
@@ -109,10 +114,12 @@ class MegacamMapper(CameraMapper):
 
         MegacamMapper._nbit_id = 64 - (MegacamMapper._nbit_tract + 2*MegacamMapper._nbit_patch
                                        + MegacamMapper._nbit_filter)
-
-        if len(afwImageUtils.Filter.getNames()) >= 2**MegacamMapper._nbit_filter:
-            raise RuntimeError("You have more filters defined than fit into the %d bits allocated" %
-                               MegacamMapper._nbit_filter)
+        with warnings.catch_warnings():
+            # surpress Filter warnings; we already know this is deprecated
+            warnings.simplefilter('ignore', category=FutureWarning)
+            if len(afwImageUtils.Filter.getNames()) >= 2**MegacamMapper._nbit_filter:
+                raise RuntimeError("You have more filters defined than fit into the %d bits allocated" %
+                                   MegacamMapper._nbit_filter)
 
     def map_defects(self, dataId, write=False):
         """Map defects dataset.


### PR DESCRIPTION
I did this as part of DM-25807 because the extra warnings from obs_cfht in jointcal were making it harder to debug those tests.