### PR TITLE
DM-22277: Exclude objectTable subset from DRP pipeline 

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -4,3 +4,4 @@ imports:
   - location: $PIPE_TASKS_DIR/pipelines/DRP.yaml
     exclude:
       - sourceTable
+      - objectTable


### PR DESCRIPTION
until we have a generic solution or a Object.yaml file for obs_cfht. 