### PR TITLE
DM-30015: Update Sphinx conf.py for documenteer 0.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-# LSST Obs package for CFHT
-
-Megacam uses the pixel scale 0.185 arcsec/pixel from <http://arxiv.org/pdf/0908.3808v1.pdf>

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,13 @@
+########
+obs_cfht
+########
+
+``obs_cfht`` is a package in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
+
+This package provides CFHT/MegaCam-specific configurations and tasks.
+Documentation is available at https://pipelines.lsst.io/modules/lsst.obs.cfht/index.html.
+
+Notes
+=====
+
+MegaCam uses the pixel scale 0.185 arcsec/pixel from http://arxiv.org/pdf/0908.3808v1.pdf.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,13 +1,13 @@
 """Sphinx configuration file for an LSST stack package.
-
-This configuration only affects single-package Sphinx documenation builds.
+This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.obs.cfht
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='obs_cfht',
-    version=lsst.obs.cfht.version.__version__))
+project = "obs_cfht"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,13 @@ max-line-length = 110
 max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503
 exclude =
-    __init__.py,
     config/*
-    megacam/camera/camera.py
+    megacam/camera/camera.py,
+    bin,
+    doc/conf.py,
+    **/*/__init__.py,
+    **/*/version.py,
+    tests/.tests
 
 
 [tool:pytest]


### PR DESCRIPTION
Updates based on the latest updates in the package template (https://github.com/lsst/templates/tree/master/project_templates/stack_package)

- Add a basic README
- Update doc/conf.py for the documenteer 0.6 Sphinx configuration API
- Update flake8 exclusions in setup.cfg