### PR TITLE
DM-32373: Run Gen 3 single frame measurement on on validation_data_cfht

### DIFF
--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -6,8 +6,14 @@ configDir = os.path.dirname(__file__)
 
 config.photoCal.colorterms.load(os.path.join(configDir, 'colorterms.py'))
 
-config.astromRefObjLoader.filterMap = {'i2': 'i'}
 config.astromRefObjLoader.ref_dataset_name = "gaia_dr2_20200414"
+# TODO DM-27843: workaround for gen3 not supporting anyFilterMapsToThis
+config.astromRefObjLoader.filterMap = {'g': 'phot_g_mean',
+                                       'r': 'phot_g_mean',
+                                       'i': 'phot_g_mean',
+                                       'z': 'phot_g_mean',
+                                       'y': 'phot_g_mean'}
+
 config.photoRefObjLoader.filterMap = {'i2': 'i'}
 config.photoRefObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
 
@@ -27,3 +33,24 @@ config.deblend.maxFootprintSize=0
 
 # Better astrometry matching
 config.astrometry.matcher.numBrightStars = 150
+
+# ====================================
+# TODO DM-31063: below are things taken from obs_subaru that should be moved
+# into a generic pipeline config once gen2 is gone.
+config.measurement.plugins.names |= ["base_CircularApertureFlux"]
+config.measurement.plugins["base_CircularApertureFlux"].radii = [3.0, 4.5, 6.0, 9.0, 12.0, 17.0, 25.0, 35.0, 50.0, 70.0]
+# Use a large aperture to be independent of seeing in calibration
+config.measurement.plugins["base_CircularApertureFlux"].maxSincRadius = 12.0
+
+import lsst.meas.extensions.photometryKron
+config.measurement.plugins.names |= ["ext_photometryKron_KronFlux"]
+
+from lsst.utils import getPackageDir
+config.measurement.load(os.path.join(getPackageDir("meas_extensions_shapeHSM"), "config", "enable.py"))
+config.measurement.plugins["ext_shapeHSM_HsmShapeRegauss"].deblendNChild = "deblend_nChild"
+# Enable debiased moments
+config.measurement.plugins.names |= ["ext_shapeHSM_HsmPsfMomentsDebiased"]
+
+
+config.measurement.plugins.names |= ["base_Jacobian", "base_FPPosition"]
+config.measurement.plugins["base_Jacobian"].pixelScale = 0.187 

--- a/config/calibrate.py
+++ b/config/calibrate.py
@@ -1,0 +1,29 @@
+import os.path
+
+from lsst.meas.astrom import MatchOptimisticBTask
+
+configDir = os.path.dirname(__file__)
+
+config.photoCal.colorterms.load(os.path.join(configDir, 'colorterms.py'))
+
+config.astromRefObjLoader.filterMap = {'i2': 'i'}
+config.astromRefObjLoader.ref_dataset_name = "gaia_dr2_20200414"
+config.photoRefObjLoader.filterMap = {'i2': 'i'}
+config.photoRefObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
+
+config.connections.astromRefCat = "gaia_dr2_20200414"
+config.connections.photoRefCat = "ps1_pv3_3pi_20170110"
+
+config.astrometry.wcsFitter.order = 3
+if isinstance(config.astrometry.matcher, MatchOptimisticBTask):
+    config.astrometry.matcher.maxMatchDistArcSec = 5
+    config.astrometry.sourceSelector['matcher'].excludePixelFlags = False
+
+config.photoCal.applyColorTerms = True
+config.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
+
+# this was the default prior to DM-11521.  New default is 2000.
+config.deblend.maxFootprintSize=0
+
+# Better astrometry matching
+config.astrometry.matcher.numBrightStars = 150

--- a/config/characterizeImage.py
+++ b/config/characterizeImage.py
@@ -3,10 +3,8 @@
 config.refObjLoader.filterMap = {'i2': 'i'}
 config.refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
 
-config.repair.doCosmicRay = True
-config.repair.cosmicray.cond3_fac = 2.5
-config.repair.cosmicray.cond3_fac2 = 0.4
-config.repair.cosmicray.niteration = 3
+# These cosmic ray defaults work for validation_data_cfht (which is post-ISR
+# data, thus not actually raw); it may not be correct for all CFHT data.
+config.requireCrForPsf = False
 config.repair.cosmicray.nCrPixelMax = 100000
-config.repair.cosmicray.minSigma = 6.0
-config.repair.cosmicray.min_DN = 150.0
+config.repair.cosmicray.min_DN = 3000

--- a/config/characterizeImage.py
+++ b/config/characterizeImage.py
@@ -1,0 +1,12 @@
+# characterize image task config for CFHT single frame measurement
+
+config.refObjLoader.filterMap = {'i2': 'i'}
+config.refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
+
+config.repair.doCosmicRay = True
+config.repair.cosmicray.cond3_fac = 2.5
+config.repair.cosmicray.cond3_fac2 = 0.4
+config.repair.cosmicray.niteration = 3
+config.repair.cosmicray.nCrPixelMax = 100000
+config.repair.cosmicray.minSigma = 6.0
+config.repair.cosmicray.min_DN = 150.0

--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -3,48 +3,16 @@ CFHT-specific overrides for processCcdTask
 """
 import os.path
 
-from lsst.utils import getPackageDir
 from lsst.obs.cfht.cfhtIsrTask import CfhtIsrTask
 
-from lsst.meas.astrom import MatchOptimisticBTask
-
-cfhtConfigDir = os.path.join(getPackageDir("obs_cfht"), "config")
-config.calibrate.photoCal.colorterms.load(os.path.join(cfhtConfigDir, 'colorterms.py'))
+configDir = os.path.dirname(__file__)
 
 config.isr.retarget(CfhtIsrTask)
 config.isr.load(os.path.join(cfhtConfigDir, "isr.py"))
 
-config.calibrate.photoCal.colorterms.load(os.path.join(cfhtConfigDir, 'colorterms.py'))
 
-config.charImage.repair.doCosmicRay = True
-config.charImage.repair.cosmicray.cond3_fac = 2.5
-config.charImage.repair.cosmicray.cond3_fac2 = 0.4
-config.charImage.repair.cosmicray.niteration = 3
-config.charImage.repair.cosmicray.nCrPixelMax = 100000
-config.charImage.repair.cosmicray.minSigma = 6.0
-config.charImage.repair.cosmicray.min_DN = 150.0
+characterizeImage = os.path.join(configDir, "characterizeImage.py")
+config.characterizeImage.load(characterizeImage)
 
-# Astrometry
-for refObjLoader in (config.calibrate.astromRefObjLoader,
-                     config.calibrate.photoRefObjLoader,
-                     config.charImage.refObjLoader,
-                     ):
-    refObjLoader.filterMap = {'i2': 'i'}
-    refObjLoader.ref_dataset_name = "ps1_pv3_3pi_20170110"
-
-config.calibrate.connections.astromRefCat = "ps1_pv3_3pi_20170110"
-config.calibrate.connections.photoRefCat = "ps1_pv3_3pi_20170110"
-
-config.calibrate.astrometry.wcsFitter.order = 3
-if isinstance(config.calibrate.astrometry.matcher, MatchOptimisticBTask):
-    config.calibrate.astrometry.matcher.maxMatchDistArcSec = 5
-    config.calibrate.astrometry.sourceSelector['matcher'].excludePixelFlags = False
-
-config.calibrate.photoCal.applyColorTerms = True
-config.calibrate.photoCal.photoCatName = "ps1_pv3_3pi_20170110"
-
-# this was the default prior to DM-11521.  New default is 2000.
-config.calibrate.deblend.maxFootprintSize=0
-
-# Better astrometry matching
-config.calibrate.astrometry.matcher.numBrightStars = 150
+calibrate = os.path.join(configDir, "calibrate.py")
+config.calibrate.load(calibrate)

--- a/python/lsst/obs/cfht/rawFormatter.py
+++ b/python/lsst/obs/cfht/rawFormatter.py
@@ -136,4 +136,5 @@ class MegaPrimeRawFormatter(FitsRawFormatterBase):
 
     def readImage(self):
         index, metadata = self._determineHDU(self.dataId["detector"])
-        return lsst.afw.image.ImageI(self.fileDescriptor.location.path, index)
+        reader = lsst.afw.image.ImageFitsReader(self.fileDescriptor.location.path, hdu=index)
+        return reader.read()

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -69,7 +69,7 @@ class MegaPrimeIngestTestCase(IngestTestBase, lsst.utils.tests.TestCase):
 
     def checkRepo(self, files=None):
         # We ignore `files` because there's only one raw file in
-        # testdata_subaru, and we know it's a science frame.
+        # testdata_cfht, and we know it's a science frame.
         # If we ever add more, this test will need to change.
         butler = Butler(self.root, collections=[self.outputRun])
         expanded = butler.registry.expandDataId(self.dataIds[0])


### PR DESCRIPTION
These changes were necessary to get a gen3 pipeline to run on validation_data_cfht, which I believe is the first gen3 run on CFHT data.