### PR TITLE
DM-32373: Fix typos that broke package

### DIFF
--- a/config/processCcd.py
+++ b/config/processCcd.py
@@ -8,11 +8,11 @@ from lsst.obs.cfht.cfhtIsrTask import CfhtIsrTask
 configDir = os.path.dirname(__file__)
 
 config.isr.retarget(CfhtIsrTask)
-config.isr.load(os.path.join(cfhtConfigDir, "isr.py"))
+config.isr.load(os.path.join(configDir, "isr.py"))
 
 
 characterizeImage = os.path.join(configDir, "characterizeImage.py")
-config.characterizeImage.load(characterizeImage)
+config.charImage.load(characterizeImage)
 
 calibrate = os.path.join(configDir, "calibrate.py")
 config.calibrate.load(calibrate)

--- a/ups/obs_cfht.table
+++ b/ups/obs_cfht.table
@@ -6,6 +6,11 @@ setupRequired(pipe_tasks)
 setupRequired(astro_metadata_translator)
 setupRequired(geom)
 
+# Required by config/calibrate.py, for gen3 DRP pipeline.
+# These can be removed after DM-30891 is finished
+setupRequired(meas_extensions_photometryKron)
+setupRequired(meas_extensions_shapeHSM)
+
 setupOptional(testdata_cfht)
 
 envPrepend(PYTHONPATH, ${PRODUCT_DIR}/python)


### PR DESCRIPTION
I accidentally broke obs_cfht with #94 . This fixes the breakages in tests/test_config.py and missing setupRequired that I didn't notice in gen3 testing. It passes local tests now.