### PR TITLE
DM-35579: Remove pipelines forwarding stubs.

### DIFF
--- a/pipelines/DRP.yaml
+++ b/pipelines/DRP.yaml
@@ -1,7 +1,0 @@
-description: DRP specialized for CFHT
-instrument: lsst.obs.cfht.MegaPrime
-imports:
-  - location: $PIPE_TASKS_DIR/pipelines/DRP.yaml
-    exclude:
-      - sourceTable
-      - objectTable


### PR DESCRIPTION
Pipelines should go in *_pipe packages.